### PR TITLE
Allow component tree to be alocated in the heap

### DIFF
--- a/include/kouta/base/root.hpp
+++ b/include/kouta/base/root.hpp
@@ -12,8 +12,24 @@ namespace kouta::base
     class Root : public Component
     {
     public:
+        /// @brief Default constructor.
+        ///
+        /// @details
+        /// This constructor assumes that the Root object will not have a parent (e.g. it is the main object of the
+        /// tree), meaning that it will not attempt to register itself with the parent, nor remove itself from its list
+        /// when being destroyed.
         Root()
-            : Component{nullptr}
+            : Root{nullptr}
+        {
+        }
+
+        /// @brief Construct from a parent.
+        ///
+        /// @details
+        /// This constructor will register the Root object with the parent **only to manage the memory deallocation** in
+        /// case the object was allocated on the heap. Regardless of having a parent, the Root owns its event loop.
+        explicit Root(Component* parent)
+            : Component{parent}
             , m_context{}
         {
         }

--- a/tests/base/dummy-component.cpp
+++ b/tests/base/dummy-component.cpp
@@ -2,6 +2,10 @@
 
 namespace kouta::tests::base
 {
+    DummyComponent::DummyComponent(Component* parent)
+        : Component{parent}
+    {}
+
     DummyComponent::DummyComponent(
         Component* parent,
         const Callback<std::uint16_t>& callback_a,
@@ -25,6 +29,12 @@ namespace kouta::tests::base
         , m_callback_b{callback_b}
         , m_callback_c{callback_c}
         , m_callback_d{callback_d}
+    {
+    }
+
+    DummyComponent::DummyComponent(Component* parent, const Callback<Component*> callback_on_delete)
+        : Component{parent}
+        , m_callback_on_delete{callback_on_delete}
     {
     }
 

--- a/tests/base/dummy-component.hpp
+++ b/tests/base/dummy-component.hpp
@@ -17,6 +17,8 @@ namespace kouta::tests::base
     public:
         DummyComponent() = delete;
 
+        explicit DummyComponent(Component* parent);
+
         DummyComponent(
             Component* parent,
             const Callback<std::uint16_t>& callback_a,
@@ -30,6 +32,8 @@ namespace kouta::tests::base
             const Callback<const std::vector<std::uint8_t>&>& callback_c,
             const Callback<std::thread::id>& callback_d);
 
+        DummyComponent(Component* parent, const Callback<Component*> callback_on_delete);
+
         // Not copyable
         DummyComponent(const DummyComponent&) = delete;
         DummyComponent& operator=(const DummyComponent&) = delete;
@@ -38,7 +42,14 @@ namespace kouta::tests::base
         DummyComponent(DummyComponent&&) = delete;
         DummyComponent& operator=(DummyComponent&&) = delete;
 
-        ~DummyComponent() override = default;
+        ~DummyComponent() override
+        {
+            // Notify that the object was deleted
+            if (m_callback_on_delete)
+            {
+                m_callback_on_delete.value()(this);
+            }
+        }
 
         /// @brief Callback invokers.
         /// @{
@@ -53,5 +64,6 @@ namespace kouta::tests::base
         Callback<std::int32_t, const std::string&> m_callback_b;
         Callback<const std::vector<std::uint8_t>&> m_callback_c;
         Callback<std::thread::id> m_callback_d;
+        std::optional<Callback<Component*>> m_callback_on_delete;
     };
 }  // namespace kouta::tests::base

--- a/tests/base/test-base.cpp
+++ b/tests/base/test-base.cpp
@@ -17,6 +17,7 @@ namespace kouta::tests::base
         MOCK_METHOD(void, handler_b, (std::int32_t value_a, const std::string& value_b), ());
         MOCK_METHOD(void, handler_c, (const std::vector<std::uint8_t>& value), ());
         MOCK_METHOD(void, handler_d, (std::thread::id), ());
+        MOCK_METHOD(void, handler_delete, (Component*), ());
     };
 
     /// @brief Test the behaviour of the empty callback.
@@ -329,7 +330,7 @@ namespace kouta::tests::base
 
         RootMock root{};
         Branch<DummyComponent> worker{
-            &worker,
+            &root,
             callback::DirectCallback{&root, &RootMock::handler_a},
             callback::DeferredCallback{&root, &RootMock::handler_b},
             callback::DeferredCallback{&root, &RootMock::handler_c},
@@ -368,5 +369,82 @@ namespace kouta::tests::base
         worker.run();
         root.run();
         alarm(0);
+    }
+
+    /// @brief Test the behaviour of a component tree when allocated in the heap.
+    ///
+    /// @details
+    /// The test succeeds if all components are deallocated.
+    TEST(BaseTest, HeapAllocation)
+    {
+        RootMock root{};
+
+        auto* dummy_base = new DummyComponent{&root, callback::DeferredCallback{&root, &RootMock::handler_delete}};
+
+        // Layer 1
+        auto* comp_a = new DummyComponent{dummy_base, callback::DeferredCallback{&root, &RootMock::handler_delete}};
+        auto* comp_b = new DummyComponent{dummy_base, callback::DeferredCallback{&root, &RootMock::handler_delete}};
+        auto* comp_c = new DummyComponent{dummy_base, callback::DeferredCallback{&root, &RootMock::handler_delete}};
+
+        // Layer 2
+        auto* comp_a1 = new DummyComponent{comp_a, callback::DeferredCallback{&root, &RootMock::handler_delete}};
+        auto* comp_a2 = new DummyComponent{comp_a, callback::DeferredCallback{&root, &RootMock::handler_delete}};
+        auto* comp_c1 = new DummyComponent{comp_c, callback::DeferredCallback{&root, &RootMock::handler_delete}};
+
+        // Layer 3
+        auto* comp_a1_1 = new DummyComponent{comp_a1, callback::DeferredCallback{&root, &RootMock::handler_delete}};
+        auto* comp_a1_2 = new DummyComponent{comp_a1, callback::DeferredCallback{&root, &RootMock::handler_delete}};
+
+        // Deletion will be in reverse creation order, but we don't really care
+        EXPECT_CALL(root, handler_delete(dummy_base))
+            .WillOnce(
+                [&root]()
+                {
+                    root.post(&RootMock::stop);
+                });
+
+        EXPECT_CALL(root, handler_delete(comp_a)).Times(1);
+        EXPECT_CALL(root, handler_delete(comp_a2)).Times(1);
+        EXPECT_CALL(root, handler_delete(comp_a1)).Times(1);
+        EXPECT_CALL(root, handler_delete(comp_a1_2)).Times(1);
+        EXPECT_CALL(root, handler_delete(comp_a1_1)).Times(1);
+
+        EXPECT_CALL(root, handler_delete(comp_b)).Times(1);
+
+        EXPECT_CALL(root, handler_delete(comp_c)).Times(1);
+        EXPECT_CALL(root, handler_delete(comp_c1)).Times(1);
+
+        delete dummy_base;
+
+        root.run();
+    }
+
+    /// @brief Test the behaviour of a component tree when allocated in the stack.
+    ///
+    /// @details
+    /// The test succeeds if no exception is thrown due to free().
+    TEST(BaseTest, StackAllocation)
+    {
+        RootMock root{};
+
+        DummyComponent dummy_base{&root};
+
+        // Layer 1
+        DummyComponent comp_a{&dummy_base};
+        DummyComponent comp_b{&dummy_base};
+        DummyComponent comp_c{&dummy_base};
+
+        // Layer 2
+        DummyComponent comp_a1{&comp_a};
+        DummyComponent comp_a2{&comp_a};
+        DummyComponent comp_c1{&comp_c};
+
+        // Layer 3
+        DummyComponent comp_a1_1{&comp_a1};
+        DummyComponent comp_a1_2{&comp_a1};
+
+        auto* comp_c1_1{&comp_c1};
+
+        // Everything is deleted in reverse order, so there shouldn't be any exceptions at this point
     }
 }  // namespace kouta::tests::base


### PR DESCRIPTION
# Changes

`Component` objects (and derived) can now be instantiated in the heap (e.g. via `new`). Parent components will keep track of their children and delete them when being destroyed themselves. When a component is destroyed, it removes itself from its parent.

For components allocated in the stack (e.g. as members of another component) this should have no effect, as they would be deleted automatically in reverse-creation order.

This is inspired by Qt's own tree structure